### PR TITLE
Fix format of CUDA_MPS_PINNED_DEVICE_MEM_LIMIT

### DIFF
--- a/cmd/nvidia-device-plugin/server.go
+++ b/cmd/nvidia-device-plugin/server.go
@@ -314,7 +314,7 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.
 		}
 		memLimits := make([]string, 0)
 		for _, mpsDevice := range requestedMPSDevices {
-			limit := fmt.Sprintf("%s:%dG", mpsDevice.Index, mpsDevice.AnnotatedID.GetMemoryGB())
+			limit := fmt.Sprintf("%s=%dG", mpsDevice.Index, mpsDevice.AnnotatedID.GetMemoryGB())
 			memLimits = append(memLimits, limit)
 		}
 		response.Envs["CUDA_MPS_PINNED_DEVICE_MEM_LIMIT"] = strings.Join(memLimits, ",")


### PR DESCRIPTION
Fixes format of `CUDA_MPS_PINNED_DEVICE_MEM_LIMIT` according to https://docs.nvidia.com/deploy/mps/index.html#topic_5_2_7. 
