### PR TITLE
synax fix for code & UT

### DIFF
--- a/internal/plugin/mps.go
+++ b/internal/plugin/mps.go
@@ -1,4 +1,4 @@
-package main
+package plugin
 
 import "github.com/NVIDIA/k8s-device-plugin/internal/rm"
 

--- a/internal/plugin/mps_test.go
+++ b/internal/plugin/mps_test.go
@@ -1,9 +1,10 @@
-package main
+package plugin
 
 import (
+	"testing"
+
 	"github.com/NVIDIA/k8s-device-plugin/internal/rm"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestMPSDeviceList_Subset(t *testing.T) {

--- a/internal/plugin/server.go
+++ b/internal/plugin/server.go
@@ -296,9 +296,8 @@ func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.
 }
 
 func (plugin *NvidiaDevicePlugin) getAllocateResponse(requestIds []string) (*pluginapi.ContainerAllocateResponse, error) {
-	mpsDevices := plugin.getMPSDevices()
-		requestedMPSDevices := mpsDevices.Subset(ids)
-		deviceIDs := plugin.deviceIDsFromAnnotatedDeviceIDs(requestIds)
+
+	deviceIDs := plugin.deviceIDsFromAnnotatedDeviceIDs(requestIds)
 
 	responseID := uuid.New().String()
 	response, err := plugin.getAllocateResponseForCDI(responseID, deviceIDs)


### PR DESCRIPTION
## Summary

Corrected the package name in the internal/plugin directory for consistency and to prevent conflicts.
Removed extraneous code that was causing golint to fail.

## Details
Before the above changes, the following errors were displayed when running go test ./... -v:
`cmd/nvidia-device-plugin/main.go:28:2: found packages plugin (api.go) and main (mps.go) in /k8s-device-plugin-nos/internal/plugin`

These errors were due to inconsistencies with package naming in the internal/plugin directory.
After applying the above fixes, go test ./... -v no longer shows any errors, indicating that the changes were successful.
```
k8s-device-plugin-nos% go test ./... -v
=== RUN   TestUnmarshalFlags
=== RUN   TestUnmarshalFlags/test_case_0
=== RUN   TestUnmarshalFlags/test_case_1
=== RUN   TestUnmarshalFlags/test_case_2
=== RUN   TestUnmarshalFlags/test_case_3
=== RUN   TestUnmarshalFlags/test_case_4
=== RUN   TestUnmarshalFlags/test_case_5
=== RUN   TestUnmarshalFlags/test_case_6
=== RUN   TestUnmarshalFlags/test_case_7
=== RUN   TestUnmarshalFlags/test_case_8
--- PASS: TestUnmarshalFlags (0.00s)
    --- PASS: TestUnmarshalFlags/test_case_0 (0.00s)
    --- PASS: TestUnmarshalFlags/test_case_1 (0.00s)
    --- PASS: TestUnmarshalFlags/test_case_2 (0.00s)
    --- PASS: TestUnmarshalFlags/test_case_3 (0.00s)
    --- PASS: TestUnmarshalFlags/test_case_4 (0.00s)
    --- PASS: TestUnmarshalFlags/test_case_5 (0.00s)
    --- PASS: TestUnmarshalFlags/test_case_6 (0.00s)
    --- PASS: TestUnmarshalFlags/test_case_7 (0.00s)
    --- PASS: TestUnmarshalFlags/test_case_8 (0.00s)
=== RUN   TestMarshalFlags
=== RUN   TestMarshalFlags/test_case_0
=== RUN   TestMarshalFlags/test_case_1
=== RUN   TestMarshalFlags/test_case_2
--- PASS: TestMarshalFlags (0.00s)
    --- PASS: TestMarshalFlags/test_case_0 (0.00s)
    --- PASS: TestMarshalFlags/test_case_1 (0.00s)
    --- PASS: TestMarshalFlags/test_case_2 (0.00s)
=== RUN   TestReplicatedDeviceRef
=== RUN   TestReplicatedDeviceRef/test_case_0
=== RUN   TestReplicatedDeviceRef/test_case_1
=== RUN   TestReplicatedDeviceRef/test_case_2
=== RUN   TestReplicatedDeviceRef/test_case_3
=== RUN   TestReplicatedDeviceRef/test_case_4
--- PASS: TestReplicatedDeviceRef (0.00s)
    --- PASS: TestReplicatedDeviceRef/test_case_0 (0.00s)
    --- PASS: TestReplicatedDeviceRef/test_case_1 (0.00s)
    --- PASS: TestReplicatedDeviceRef/test_case_2 (0.00s)
    --- PASS: TestReplicatedDeviceRef/test_case_3 (0.00s)
    --- PASS: TestReplicatedDeviceRef/test_case_4 (0.00s)
=== RUN   TestMarshalReplicatedDevices
=== RUN   TestMarshalReplicatedDevices/test_case_0
=== RUN   TestMarshalReplicatedDevices/test_case_1
=== RUN   TestMarshalReplicatedDevices/test_case_2
=== RUN   TestMarshalReplicatedDevices/test_case_3
--- PASS: TestMarshalReplicatedDevices (0.00s)
    --- PASS: TestMarshalReplicatedDevices/test_case_0 (0.00s)
    --- PASS: TestMarshalReplicatedDevices/test_case_1 (0.00s)
    --- PASS: TestMarshalReplicatedDevices/test_case_2 (0.00s)
    --- PASS: TestMarshalReplicatedDevices/test_case_3 (0.00s)
=== RUN   TestUnmarshalReplicatedDevices
=== RUN   TestUnmarshalReplicatedDevices/test_case_0
=== RUN   TestUnmarshalReplicatedDevices/test_case_1
=== RUN   TestUnmarshalReplicatedDevices/test_case_2
=== RUN   TestUnmarshalReplicatedDevices/test_case_3
=== RUN   TestUnmarshalReplicatedDevices/test_case_4
=== RUN   TestUnmarshalReplicatedDevices/test_case_5
=== RUN   TestUnmarshalReplicatedDevices/test_case_6
=== RUN   TestUnmarshalReplicatedDevices/test_case_7
=== RUN   TestUnmarshalReplicatedDevices/test_case_8
=== RUN   TestUnmarshalReplicatedDevices/test_case_9
=== RUN   TestUnmarshalReplicatedDevices/test_case_10
=== RUN   TestUnmarshalReplicatedDevices/test_case_11
=== RUN   TestUnmarshalReplicatedDevices/test_case_12
=== RUN   TestUnmarshalReplicatedDevices/test_case_13
=== RUN   TestUnmarshalReplicatedDevices/test_case_14
=== RUN   TestUnmarshalReplicatedDevices/test_case_15
=== RUN   TestUnmarshalReplicatedDevices/test_case_16
=== RUN   TestUnmarshalReplicatedDevices/test_case_17
=== RUN   TestUnmarshalReplicatedDevices/test_case_18
=== RUN   TestUnmarshalReplicatedDevices/test_case_19
--- PASS: TestUnmarshalReplicatedDevices (0.02s)
    --- PASS: TestUnmarshalReplicatedDevices/test_case_0 (0.00s)
    --- PASS: TestUnmarshalReplicatedDevices/test_case_1 (0.00s)
    --- PASS: TestUnmarshalReplicatedDevices/test_case_2 (0.00s)
    --- PASS: TestUnmarshalReplicatedDevices/test_case_3 (0.00s)
    --- PASS: TestUnmarshalReplicatedDevices/test_case_4 (0.00s)
    --- PASS: TestUnmarshalReplicatedDevices/test_case_5 (0.00s)
    --- PASS: TestUnmarshalReplicatedDevices/test_case_6 (0.00s)
    --- PASS: TestUnmarshalReplicatedDevices/test_case_7 (0.00s)
    --- PASS: TestUnmarshalReplicatedDevices/test_case_8 (0.00s)
    --- PASS: TestUnmarshalReplicatedDevices/test_case_9 (0.00s)
    --- PASS: TestUnmarshalReplicatedDevices/test_case_10 (0.00s)
    --- PASS: TestUnmarshalReplicatedDevices/test_case_11 (0.00s)
    --- PASS: TestUnmarshalReplicatedDevices/test_case_12 (0.00s)
    --- PASS: TestUnmarshalReplicatedDevices/test_case_13 (0.00s)
    --- PASS: TestUnmarshalReplicatedDevices/test_case_14 (0.00s)
    --- PASS: TestUnmarshalReplicatedDevices/test_case_15 (0.00s)
    --- PASS: TestUnmarshalReplicatedDevices/test_case_16 (0.00s)
    --- PASS: TestUnmarshalReplicatedDevices/test_case_17 (0.00s)
    --- PASS: TestUnmarshalReplicatedDevices/test_case_18 (0.00s)
    --- PASS: TestUnmarshalReplicatedDevices/test_case_19 (0.02s)
=== RUN   TestUnmarshalReplicatedResource
=== RUN   TestUnmarshalReplicatedResource/test_case_0
=== RUN   TestUnmarshalReplicatedResource/test_case_1
=== RUN   TestUnmarshalReplicatedResource/test_case_2
=== RUN   TestUnmarshalReplicatedResource/test_case_3
=== RUN   TestUnmarshalReplicatedResource/test_case_4
=== RUN   TestUnmarshalReplicatedResource/test_case_5
=== RUN   TestUnmarshalReplicatedResource/test_case_6
=== RUN   TestUnmarshalReplicatedResource/test_case_7
=== RUN   TestUnmarshalReplicatedResource/test_case_8
=== RUN   TestUnmarshalReplicatedResource/test_case_9
=== RUN   TestUnmarshalReplicatedResource/test_case_10
=== RUN   TestUnmarshalReplicatedResource/test_case_11
=== RUN   TestUnmarshalReplicatedResource/test_case_12
--- PASS: TestUnmarshalReplicatedResource (0.00s)
    --- PASS: TestUnmarshalReplicatedResource/test_case_0 (0.00s)
    --- PASS: TestUnmarshalReplicatedResource/test_case_1 (0.00s)
    --- PASS: TestUnmarshalReplicatedResource/test_case_2 (0.00s)
    --- PASS: TestUnmarshalReplicatedResource/test_case_3 (0.00s)
    --- PASS: TestUnmarshalReplicatedResource/test_case_4 (0.00s)
    --- PASS: TestUnmarshalReplicatedResource/test_case_5 (0.00s)
    --- PASS: TestUnmarshalReplicatedResource/test_case_6 (0.00s)
    --- PASS: TestUnmarshalReplicatedResource/test_case_7 (0.00s)
    --- PASS: TestUnmarshalReplicatedResource/test_case_8 (0.00s)
    --- PASS: TestUnmarshalReplicatedResource/test_case_9 (0.00s)
    --- PASS: TestUnmarshalReplicatedResource/test_case_10 (0.00s)
    --- PASS: TestUnmarshalReplicatedResource/test_case_11 (0.00s)
    --- PASS: TestUnmarshalReplicatedResource/test_case_12 (0.00s)
=== RUN   TestUnmarshalTimeSlicing
=== RUN   TestUnmarshalTimeSlicing/test_case_0
=== RUN   TestUnmarshalTimeSlicing/test_case_1
=== RUN   TestUnmarshalTimeSlicing/test_case_2
=== RUN   TestUnmarshalTimeSlicing/test_case_3
=== RUN   TestUnmarshalTimeSlicing/test_case_4
=== RUN   TestUnmarshalTimeSlicing/test_case_5
--- PASS: TestUnmarshalTimeSlicing (0.00s)
    --- PASS: TestUnmarshalTimeSlicing/test_case_0 (0.00s)
    --- PASS: TestUnmarshalTimeSlicing/test_case_1 (0.00s)
    --- PASS: TestUnmarshalTimeSlicing/test_case_2 (0.00s)
    --- PASS: TestUnmarshalTimeSlicing/test_case_3 (0.00s)
    --- PASS: TestUnmarshalTimeSlicing/test_case_4 (0.00s)
    --- PASS: TestUnmarshalTimeSlicing/test_case_5 (0.00s)
=== RUN   TestUnmarshalMPS
=== RUN   TestUnmarshalMPS/All_fields_with_value
--- PASS: TestUnmarshalMPS (0.00s)
    --- PASS: TestUnmarshalMPS/All_fields_with_value (0.00s)
PASS
ok      github.com/NVIDIA/k8s-device-plugin/api/config/v1       (cached)
?       github.com/NVIDIA/k8s-device-plugin/cmd/config-manager  [no test files]
?       github.com/NVIDIA/k8s-device-plugin/cmd/nvidia-device-plugin    [no test files]
?       github.com/NVIDIA/k8s-device-plugin/internal/cdi        [no test files]
?       github.com/NVIDIA/k8s-device-plugin/internal/info       [no test files]
?       github.com/NVIDIA/k8s-device-plugin/internal/mig        [no test files]
?       github.com/NVIDIA/k8s-device-plugin/internal/plugin/manager     [no test files]
=== RUN   TestMPSDeviceList_Subset
=== RUN   TestMPSDeviceList_Subset/empty_list,_empty_ids
=== RUN   TestMPSDeviceList_Subset/empty_list:_subset_should_be_empty
=== RUN   TestMPSDeviceList_Subset/subset_should_return_only_MPSDevices_with_provided_IDs
=== RUN   TestMPSDeviceList_Subset/subset_should_consider_only_annotated_IDs
--- PASS: TestMPSDeviceList_Subset (0.00s)
    --- PASS: TestMPSDeviceList_Subset/empty_list,_empty_ids (0.00s)
    --- PASS: TestMPSDeviceList_Subset/empty_list:_subset_should_be_empty (0.00s)
    --- PASS: TestMPSDeviceList_Subset/subset_should_return_only_MPSDevices_with_provided_IDs (0.00s)
    --- PASS: TestMPSDeviceList_Subset/subset_should_consider_only_annotated_IDs (0.00s)
=== RUN   TestCDIAllocateResponse
=== RUN   TestCDIAllocateResponse/empty_device_list_has_empty_response
=== RUN   TestCDIAllocateResponse/CDI_disabled_has_empty_response
=== RUN   TestCDIAllocateResponse/single_device_is_added_to_annotations
=== RUN   TestCDIAllocateResponse/single_device_is_added_to_annotations_with_custom_prefix
=== RUN   TestCDIAllocateResponse/multiple_devices_are_added_to_annotations
=== RUN   TestCDIAllocateResponse/multiple_devices_are_added_to_annotations_with_custom_prefix
=== RUN   TestCDIAllocateResponse/mofed_devices_are_selected_if_configured
=== RUN   TestCDIAllocateResponse/gds_devices_are_selected_if_configured
=== RUN   TestCDIAllocateResponse/gds_and_mofed_devices_are_included_with_device_ids
--- PASS: TestCDIAllocateResponse (0.00s)
    --- PASS: TestCDIAllocateResponse/empty_device_list_has_empty_response (0.00s)
    --- PASS: TestCDIAllocateResponse/CDI_disabled_has_empty_response (0.00s)
    --- PASS: TestCDIAllocateResponse/single_device_is_added_to_annotations (0.00s)
    --- PASS: TestCDIAllocateResponse/single_device_is_added_to_annotations_with_custom_prefix (0.00s)
    --- PASS: TestCDIAllocateResponse/multiple_devices_are_added_to_annotations (0.00s)
    --- PASS: TestCDIAllocateResponse/multiple_devices_are_added_to_annotations_with_custom_prefix (0.00s)
    --- PASS: TestCDIAllocateResponse/mofed_devices_are_selected_if_configured (0.00s)
    --- PASS: TestCDIAllocateResponse/gds_devices_are_selected_if_configured (0.00s)
    --- PASS: TestCDIAllocateResponse/gds_and_mofed_devices_are_included_with_device_ids (0.00s)
PASS
ok      github.com/NVIDIA/k8s-device-plugin/internal/plugin     (cached)
=== RUN   TestDeviceMapInsert
=== RUN   TestDeviceMapInsert/insert_into_empty_map
=== RUN   TestDeviceMapInsert/add_to_existing_resource
=== RUN   TestDeviceMapInsert/add_new_resource
=== RUN   TestDeviceMapInsert/overwrite_existing_device
--- PASS: TestDeviceMapInsert (0.00s)
    --- PASS: TestDeviceMapInsert/insert_into_empty_map (0.00s)
    --- PASS: TestDeviceMapInsert/add_to_existing_resource (0.00s)
    --- PASS: TestDeviceMapInsert/add_new_resource (0.00s)
    --- PASS: TestDeviceMapInsert/overwrite_existing_device (0.00s)
=== RUN   TestAddMPSReplicas
=== RUN   TestAddMPSReplicas/DeviceMap_is_empty
=== RUN   TestAddMPSReplicas/Config_has_no_MPS_devices,_should_not_add_replicas
=== RUN   TestAddMPSReplicas/For_device_with_MPS_replicas,_result_map_should_include_only_annotated_device_IDs
--- PASS: TestAddMPSReplicas (0.00s)
    --- PASS: TestAddMPSReplicas/DeviceMap_is_empty (0.00s)
    --- PASS: TestAddMPSReplicas/Config_has_no_MPS_devices,_should_not_add_replicas (0.00s)
    --- PASS: TestAddMPSReplicas/For_device_with_MPS_replicas,_result_map_should_include_only_annotated_device_IDs (0.00s)
=== RUN   TestMPSAnnotatedID__Split
=== RUN   TestMPSAnnotatedID__Split/Annotated_MPS_ID_with_memory_and_replicas
=== RUN   TestMPSAnnotatedID__Split/Annotated_ID,_not_MPS:_should_return_whole_string_as_first_part
=== RUN   TestMPSAnnotatedID__Split/Non-annotated_ID,_should_return_whole_string_as_first_part
--- PASS: TestMPSAnnotatedID__Split (0.00s)
    --- PASS: TestMPSAnnotatedID__Split/Annotated_MPS_ID_with_memory_and_replicas (0.00s)
    --- PASS: TestMPSAnnotatedID__Split/Annotated_ID,_not_MPS:_should_return_whole_string_as_first_part (0.00s)
    --- PASS: TestMPSAnnotatedID__Split/Non-annotated_ID,_should_return_whole_string_as_first_part (0.00s)
=== RUN   TestGetAdditionalXids
=== RUN   TestGetAdditionalXids/test_case_0
=== RUN   TestGetAdditionalXids/test_case_1
=== RUN   TestGetAdditionalXids/test_case_2
I0116 06:50:06.730210   23836 health.go:207] Ignoring malformed Xid value not-an-int: strconv.ParseUint: parsing "not-an-int": invalid syntax
=== RUN   TestGetAdditionalXids/test_case_3
=== RUN   TestGetAdditionalXids/test_case_4
I0116 06:50:06.730431   23836 health.go:207] Ignoring malformed Xid value -68: strconv.ParseUint: parsing "-68": invalid syntax
=== RUN   TestGetAdditionalXids/test_case_5
=== RUN   TestGetAdditionalXids/test_case_6
=== RUN   TestGetAdditionalXids/test_case_7
=== RUN   TestGetAdditionalXids/test_case_8
=== RUN   TestGetAdditionalXids/test_case_9
I0116 06:50:06.730552   23836 health.go:207] Ignoring malformed Xid value not-an-int: strconv.ParseUint: parsing "not-an-int": invalid syntax
--- PASS: TestGetAdditionalXids (0.00s)
    --- PASS: TestGetAdditionalXids/test_case_0 (0.00s)
    --- PASS: TestGetAdditionalXids/test_case_1 (0.00s)
    --- PASS: TestGetAdditionalXids/test_case_2 (0.00s)
    --- PASS: TestGetAdditionalXids/test_case_3 (0.00s)
    --- PASS: TestGetAdditionalXids/test_case_4 (0.00s)
    --- PASS: TestGetAdditionalXids/test_case_5 (0.00s)
    --- PASS: TestGetAdditionalXids/test_case_6 (0.00s)
    --- PASS: TestGetAdditionalXids/test_case_7 (0.00s)
    --- PASS: TestGetAdditionalXids/test_case_8 (0.00s)
    --- PASS: TestGetAdditionalXids/test_case_9 (0.00s)
PASS
ok      github.com/NVIDIA/k8s-device-plugin/internal/rm (cached)
```
